### PR TITLE
27 cannot backproject from compressed image

### DIFF
--- a/python/ouroboros/pipeline/backproject_pipeline.py
+++ b/python/ouroboros/pipeline/backproject_pipeline.py
@@ -96,7 +96,15 @@ class BackprojectPipelineStep(PipelineStep):
                 is_compressed = bool(tif.pages[0].compression)
                 FPShape = FrontProjStack(D=len(tif.pages), V=tif.pages[0].shape[0], U=tif.pages[0].shape[1])
 
-        if is_compressed:
+        cannot_memmap = False
+        try:
+            _ = tifffile.memmap(straightened_volume_path, mode="r")
+        except:     # noqa: E722
+            # Check here is because memmap needs certain types of dataoffsets, which aren't always there
+			# separate to compression.
+            cannot_memmap = True
+
+        if is_compressed or cannot_memmap:
             print("Input data compressed; Rewriting.")
 
             # Create a new path for the straightened volume

--- a/python/ouroboros/pipeline/backproject_pipeline.py
+++ b/python/ouroboros/pipeline/backproject_pipeline.py
@@ -98,10 +98,13 @@ class BackprojectPipelineStep(PipelineStep):
 
         cannot_memmap = False
         try:
-            _ = tifffile.memmap(straightened_volume_path, mode="r")
+            if Path(straightened_volume_path).is_dir():
+                _ = tifffile.memmap(next(Path(straightened_volume_path).iterdir()), mode="r")
+            else:
+                _ = tifffile.memmap(straightened_volume_path, mode="r")
         except:     # noqa: E722
             # Check here is because memmap needs certain types of dataoffsets, which aren't always there
-			# separate to compression.
+            # separate to compression.
             cannot_memmap = True
 
         if is_compressed or cannot_memmap:


### PR DESCRIPTION
Fixes #27 

- Was not actually compression, was certain non-compressed files.
- memmap check (within tifffile) is to certain dataoffsets at the moment; unsure of precise file format details
- Both tiff stacks and single images.